### PR TITLE
Clear indexes before regenerating them

### DIFF
--- a/volxfastscroll/src/main/java/com/volcaniccoder/volxfastscroll/Volx.java
+++ b/volxfastscroll/src/main/java/com/volcaniccoder/volxfastscroll/Volx.java
@@ -107,11 +107,6 @@ public class Volx implements Runnable {
         Class foo = objectList.get(0).getClass();
         int counter = -1;
 
-        allStringList.clear();
-        charArr.clear();
-        charList.clear();
-        positionList.clear();
-
         for (Object obj : objectList) {
 
             counter++;
@@ -330,7 +325,15 @@ public class Volx implements Runnable {
     public void notifyValueDataChanged() {
         parentLayout.removeView(rightIndicatorLayout);
         parentLayout.removeView(middleText);
+        clearIndexes();
         execute();
+    }
+
+    private void clearIndexes() {
+        allStringList.clear();
+        charArr.clear();
+        charList.clear();
+        positionList.clear();
     }
 
     private void onScreenCreated(int height, ViewTreeObserver.OnGlobalLayoutListener listener) {

--- a/volxfastscroll/src/main/java/com/volcaniccoder/volxfastscroll/Volx.java
+++ b/volxfastscroll/src/main/java/com/volcaniccoder/volxfastscroll/Volx.java
@@ -107,6 +107,11 @@ public class Volx implements Runnable {
         Class foo = objectList.get(0).getClass();
         int counter = -1;
 
+        allStringList.clear();
+        charArr.clear();
+        charList.clear();
+        positionList.clear();
+
         for (Object obj : objectList) {
 
             counter++;


### PR DESCRIPTION
Hi!

I noticed that when calling notifyValueDataChanged() the new indexes were appended at the end instead of replacing them all.
The changes in this pull request clear the corresponding arrays before adding the contents to them again.